### PR TITLE
Add queue implementation in Python

### DIFF
--- a/data-structures/queue/queue.py
+++ b/data-structures/queue/queue.py
@@ -1,0 +1,55 @@
+class Node:
+    """Represents a node in a linked list"""
+
+    def __init__(self, value):
+        self.value = value
+        self.next = None
+
+    def append(self, node):
+        self.next = node
+
+
+class Queue:
+    """
+    Represents a queue.
+    This implementation of the queue is based on a linked list.
+    Unit tests in the file: queue_tests.py
+
+    Complexity analysis of the queue operations:
+
+    Time:
+    * Enqueue: O(1), add an element at the end of the queue
+    * Dequeue: O(1), remove the first element of the queue
+    * Search: O(n), traverse the queue until you find the required element.
+                    In the worst case scenario you need to traverse the whole queue, therefore the time
+                    complexity is O(n)
+
+    Space:
+    The space required to hold the queue in memory is O(n).
+    """
+
+    def __init__(self):
+        self.size = 0
+        self.first = None
+        self.last = None
+
+    def __is_empty(self):
+        return self.first is None
+
+    def enqueue(self, value):
+        new_node = Node(value)
+        if self.__is_empty():
+            self.first = new_node
+            self.last = new_node
+        else:
+            self.last.append(new_node)
+            self.last = new_node
+        self.size += 1
+
+    def dequeue(self):
+        if self.__is_empty():
+            return None
+        current_first = self.first
+        self.first = current_first.next
+        self.size -= 1
+        return current_first.value

--- a/data-structures/queue/queue_tests.py
+++ b/data-structures/queue/queue_tests.py
@@ -1,0 +1,70 @@
+import unittest
+from queue import Queue
+
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_enqueue_to_empty_queue(self):
+        queue = Queue()
+        self.assertEqual(queue.size, 0, "Queue should be empty")
+        queue.enqueue(1)
+        self.assertEqual(queue.size, 1, "Queue should contain one element")
+
+    def test_enqueue_non_empty_queue(self):
+        queue = Queue()
+        queue.enqueue(1)
+        queue.enqueue(2)
+        queue.enqueue(3)
+        queue.enqueue(4)
+        queue.enqueue(5)
+        self.assertEqual(queue.size, 5, "Queue should contain one element")
+
+    def test_dequeue_empty_queue(self):
+        queue = Queue()
+        self.assertEqual(queue.size, 0, "Queue should be empty")
+        element = queue.dequeue()
+        self.assertIsNone(element)
+        self.assertEqual(queue.size, 0, "Queue should be empty")
+
+        queue.dequeue()
+        queue.dequeue()
+        queue.dequeue()
+        self.assertEqual(queue.size, 0, "Queue should be empty")
+
+    def test_dequeue_non_empty_queue(self):
+        queue = Queue()
+        queue.enqueue(1)
+        queue.enqueue(2)
+        queue.enqueue(3)
+        queue.enqueue(4)
+        queue.enqueue(5)
+        self.assertEqual(queue.size, 5, "Queue should contain one element")
+
+        # Test FIFO (first in first out)
+        one = queue.dequeue()
+        self.assertEqual(one, 1, "Should be 1")
+        self.assertEqual(queue.size, 5 - 1, "Queue size should decrease")
+
+        two = queue.dequeue()
+        self.assertEqual(two, 2, "Should be 2")
+        self.assertEqual(queue.size, 5 - 2, "Queue size should decrease")
+
+        three = queue.dequeue()
+        self.assertEqual(three, 3, "Should be 3")
+        self.assertEqual(queue.size, 5 - 3, "Queue size should decrease")
+
+        four = queue.dequeue()
+        self.assertEqual(four, 4, "Should be 4")
+        self.assertEqual(queue.size, 5 - 4, "Queue size should decrease")
+
+        five = queue.dequeue()
+        self.assertEqual(five, 5, "Should be 5")
+        self.assertEqual(queue.size, 5 - 5, "Queue size should decrease")
+
+        none = queue.dequeue()
+        self.assertIsNone(none, "Queue should be empty")
+        self.assertEqual(queue.size, 0, "Queue should be empty")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/data-structures/stack/stack.py
+++ b/data-structures/stack/stack.py
@@ -3,11 +3,7 @@ class Node:
 
     def __init__(self, value):
         self.value = value
-        self.previous = None
         self.next = None
-
-    def prepend(self, node):
-        self.previous = node
 
     def append(self, node):
         self.next = node

--- a/data-structures/stack/stack_tests.py
+++ b/data-structures/stack/stack_tests.py
@@ -27,16 +27,16 @@ class TestStringMethods(unittest.TestCase):
 
         # Verify LIFO: last in first out
         self.assertEqual(stack.pop(), 5)
-        self.assertEquals(stack.size, 4)
+        self.assertEqual(stack.size, 4)
 
         self.assertEqual(stack.pop(), 4)
-        self.assertEquals(stack.size, 3)
+        self.assertEqual(stack.size, 3)
 
         self.assertEqual(stack.pop(), 3)
-        self.assertEquals(stack.size, 2)
+        self.assertEqual(stack.size, 2)
 
         self.assertEqual(stack.pop(), 2)
-        self.assertEquals(stack.size, 1)
+        self.assertEqual(stack.size, 1)
 
         self.assertEqual(stack.pop(), 1)
         self.assertEqual(stack.size, 0)
@@ -54,22 +54,22 @@ class TestStringMethods(unittest.TestCase):
         stack.push('a')
         stack.push('b')
         stack.push('c')
-        self.assertEquals(stack.size, 3)
+        self.assertEqual(stack.size, 3)
 
-        self.assertEquals(stack.pop(), 'c')
-        self.assertEquals(stack.pop(), 'b')
-        self.assertEquals(stack.pop(), 'a')
-        self.assertEquals(stack.size, 0)
+        self.assertEqual(stack.pop(), 'c')
+        self.assertEqual(stack.pop(), 'b')
+        self.assertEqual(stack.pop(), 'a')
+        self.assertEqual(stack.size, 0)
 
     def test_supports_multiple_types(self):
         stack = Stack()
         stack.push(1)
         stack.push('b')
-        self.assertEquals(stack.size, 2)
+        self.assertEqual(stack.size, 2)
 
-        self.assertEquals(stack.pop(), 'b')
-        self.assertEquals(stack.pop(), 1)
-        self.assertEquals(stack.size, 0)
+        self.assertEqual(stack.pop(), 'b')
+        self.assertEqual(stack.pop(), 1)
+        self.assertEqual(stack.size, 0)
 
 
 


### PR DESCRIPTION
Main changes:

1. Remove unused `previous` field in stack implementation
1. Add tests for queue implementation
1. Add queue implementation