### PR TITLE
Add queue tests and implementation in golang

### DIFF
--- a/data-structures/queue/queue.go
+++ b/data-structures/queue/queue.go
@@ -1,0 +1,61 @@
+package queue
+
+// Node in a linked list.
+type node struct {
+	value interface{}
+	next  *node
+}
+
+// Queue implemented using a linked list.
+// The unit tests are in file: queue_tests.go
+//
+// Complexity analysis of the queue operations:
+//
+// Time:
+// * Enqueue: O(1), add an element at the end of the queue.
+// * Dequeue: O(1), remove the first element of the queue.
+// * Search:  O(n), traverse the queue until you find the required element.
+// 				    In the worst case scenario you need to traverse the whole queue,
+// 				    therefore the time complexity is O(n)
+//
+// Space:
+// The space required to hold the queue in memory is O(n).
+type Queue struct {
+	size  int
+	first *node
+	last  *node
+}
+
+// isEmpty returns true if the queue is empty, otherwise returns false.
+func (q *Queue) isEmpty() bool {
+	return q.first == nil
+}
+
+// Enqueue adds an element at the end of the queue.
+func (q *Queue) Enqueue(value interface{}) {
+	n := &node{value: value, next: nil}
+	if q.isEmpty() {
+		q.first = n
+		q.last = n
+	} else {
+		q.last.next = n
+		q.last = n
+	}
+	q.size++
+}
+
+// Dequeue returns the first element and removes it from the queue.
+func (q *Queue) Dequeue() interface{} {
+	if q.isEmpty() {
+		return nil
+	}
+	result := q.first
+	q.first = result.next
+	q.size--
+	return result.value
+}
+
+// Size returns number of elements in the queue.
+func (q *Queue) Size() int {
+	return q.size
+}

--- a/data-structures/queue/queue_test.go
+++ b/data-structures/queue/queue_test.go
@@ -1,0 +1,81 @@
+package queue
+
+import (
+	"testing"
+)
+
+func TestEnqueueToEmptyQueue(t *testing.T) {
+	q := Queue{}
+	verifyInt(t, q.Size(), 0)
+	q.Enqueue(1)
+	verifyInt(t, q.Size(), 1)
+}
+
+func TestEnqueueToNonEmptyQueue(t *testing.T) {
+	q := Queue{}
+	q.Enqueue(1)
+	q.Enqueue(2)
+	q.Enqueue(3)
+	q.Enqueue(4)
+	q.Enqueue(5)
+	verifyInt(t, q.Size(), 5)
+}
+
+func TestDequeueEmptyQueue(t *testing.T) {
+	q := Queue{}
+	verifyInt(t, q.Size(), 0)
+
+	element := q.Dequeue()
+	if element != nil {
+		t.Errorf("Element should be nil, it's %s", element)
+	}
+
+	// Size does not go below zero
+	verifyInt(t, q.Size(), 0)
+}
+
+func TestDequeueNonEmptyQueue(t *testing.T) {
+	q := Queue{}
+	verifyInt(t, q.Size(), 0)
+
+	q.Enqueue(1)
+	q.Enqueue(2)
+	q.Enqueue(3)
+	q.Enqueue(4)
+	q.Enqueue(5)
+	verifyInt(t, q.Size(), 5)
+
+	one := q.Dequeue()
+	verifyInt(t, one, 1)
+	verifyInt(t, q.Size(), 5-1)
+
+	two := q.Dequeue()
+	verifyInt(t, two, 2)
+	verifyInt(t, q.Size(), 5-2)
+
+	three := q.Dequeue()
+	verifyInt(t, three, 3)
+	verifyInt(t, q.Size(), 5-3)
+
+	four := q.Dequeue()
+	verifyInt(t, four, 4)
+	verifyInt(t, q.Size(), 5-4)
+
+	five := q.Dequeue()
+	verifyInt(t, five, 5)
+	verifyInt(t, q.Size(), 5-5)
+
+	// Size does not go below zero
+	q.Dequeue()
+	q.Dequeue()
+	q.Dequeue()
+	q.Dequeue()
+	verifyInt(t, q.Size(), 0)
+}
+
+func verifyInt(t *testing.T, real interface{}, expected int) {
+	realInt := real.(int)
+	if realInt != expected {
+		t.Errorf("Expected %d, real %d", expected, real)
+	}
+}


### PR DESCRIPTION
Main changes:

1. Add unit tests for a queue in golang.
1. Implement a queue using a linked list in golang.

**Why did I re-implement the queue in golang?**

The Python implementation of the queue worked because of Python's pass by assignment. See: https://stackoverflow.com/a/986145/2420718

When the Python implementation worked it felt like magic. I was expecting it to fail because I thought that the arguments were passed by value.

After learning about Python's passing by assignment, I decided to implement it in golang to uncover the magic, AKA explicitly pass arguments by reference.
